### PR TITLE
Fix slice index bug in calendar views

### DIFF
--- a/src/views/FourWeekView.vue
+++ b/src/views/FourWeekView.vue
@@ -175,7 +175,7 @@ const closeModal = () => {
 
     <svg :viewBox="`0 0 ${viewBoxSize} ${viewBoxSize}`" class="pie-chart-svg">
       <g
-        v-for="sliceData in slicesWithEvents"
+        v-for="(sliceData, index) in slicesWithEvents"
         :key="sliceData.id"
         class="slice-group"
         @click="handleSliceClick(sliceData, index)"

--- a/src/views/SevenDayView.vue
+++ b/src/views/SevenDayView.vue
@@ -176,7 +176,7 @@ const closeModal = () => {
 
     <svg :viewBox="`0 0 ${viewBoxSize} ${viewBoxSize}`" class="pie-chart-svg">
       <g
-        v-for="sliceData in slicesWithEvents"
+        v-for="(sliceData, index) in slicesWithEvents"
         :key="sliceData.id"
         class="slice-group"
         @click="handleSliceClick(sliceData, index)"

--- a/src/views/TwelveHourView.vue
+++ b/src/views/TwelveHourView.vue
@@ -193,7 +193,7 @@ const closeModal = () => {
     <svg :viewBox="`0 0 ${viewBoxSize} ${viewBoxSize}`" class="pie-chart-svg">
       <!-- Group for each slice and its dots -->
       <g
-        v-for="sliceData in slicesWithEvents"
+        v-for="(sliceData, index) in slicesWithEvents"
         :key="sliceData.id"
         class="slice-group"
         @click="handleSliceClick(sliceData, index)"


### PR DESCRIPTION
## Summary
- fix incorrect v-for loops in calendar views so slice index is available to click handlers

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run type-check` *(fails: vue-tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f43b0c19c833289e5940e39cef92d