### PR TITLE
Refactor interfaces

### DIFF
--- a/src/types/CalendarEvent.ts
+++ b/src/types/CalendarEvent.ts
@@ -1,0 +1,6 @@
+export interface CalendarEvent {
+  id: string
+  sliceIndex: number
+  name: string
+  color: string
+}

--- a/src/types/EventDot.ts
+++ b/src/types/EventDot.ts
@@ -1,0 +1,7 @@
+export interface EventDot {
+  id: string
+  cx: number
+  cy: number
+  fill: string
+  radius: number
+}

--- a/src/types/SliceData.ts
+++ b/src/types/SliceData.ts
@@ -1,0 +1,9 @@
+import type { EventDot } from './EventDot'
+import type { CalendarEvent } from './CalendarEvent'
+
+export interface SliceData {
+  id: string
+  d: string
+  eventDots: EventDot[]
+  originalEvents: CalendarEvent[]
+}

--- a/src/views/FourWeekView.vue
+++ b/src/views/FourWeekView.vue
@@ -1,29 +1,10 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import EventListModal from '../components/EventListModal.vue'
+import type { CalendarEvent } from '../types/CalendarEvent'
+import type { EventDot } from '../types/EventDot'
+import type { SliceData } from '../types/SliceData'
 
-// --- Data Structures ---
-interface CalendarEvent {
-  id: string // Unique ID for the event
-  sliceIndex: number // 0-3, corresponds to the slice index (0 = first slice)
-  name: string // Description of the event
-  color: string // Color for the dot
-}
-
-interface EventDot {
-  id: string
-  cx: number
-  cy: number
-  fill: string
-  radius: number
-}
-
-interface SliceData {
-  id: string
-  d: string // SVG path data for the slice
-  eventDots: EventDot[]
-  originalEvents: CalendarEvent[] // To pass to the modal
-}
 
 // --- Sample Event Data ---
 // (sliceIndex: 0 is the first slice)

--- a/src/views/SevenDayView.vue
+++ b/src/views/SevenDayView.vue
@@ -1,29 +1,10 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import EventListModal from '../components/EventListModal.vue'
+import type { CalendarEvent } from '../types/CalendarEvent'
+import type { EventDot } from '../types/EventDot'
+import type { SliceData } from '../types/SliceData'
 
-// --- Data Structures ---
-interface CalendarEvent {
-  id: string // Unique ID for the event
-  sliceIndex: number // 0-6, corresponds to the slice index (0 = first slice)
-  name: string // Description of the event
-  color: string // Color for the dot
-}
-
-interface EventDot {
-  id: string
-  cx: number
-  cy: number
-  fill: string
-  radius: number
-}
-
-interface SliceData {
-  id: string
-  d: string // SVG path data for the slice
-  eventDots: EventDot[]
-  originalEvents: CalendarEvent[] // To pass to the modal
-}
 
 // --- Sample Event Data ---
 // (sliceIndex: 0 is the first slice)

--- a/src/views/TwelveHourView.vue
+++ b/src/views/TwelveHourView.vue
@@ -1,40 +1,20 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import EventListModal from '../components/EventListModal.vue'
-
-// --- Data Structures ---
-interface CalendarEvent {
-  id: string // Unique ID for the event
-  hour: number // 0-11, corresponds to the slice index (0 = 12 o'clock position)
-  name: string // Description of the event
-  color: string // Color for the dot
-}
-
-interface EventDot {
-  id: string
-  cx: number
-  cy: number
-  fill: string
-  radius: number
-}
-
-interface SliceData {
-  id: string
-  d: string // SVG path data for the slice
-  eventDots: EventDot[]
-  originalEvents: CalendarEvent[] // To pass to the modal
-}
+import type { CalendarEvent } from '../types/CalendarEvent'
+import type { EventDot } from '../types/EventDot'
+import type { SliceData } from '../types/SliceData'
 
 // --- Sample Event Data ---
-// (hour: 0 is the first slice, typically 12 o'clock)
+// (sliceIndex: 0 is the first slice, typically 12 o'clock)
 const events = ref<CalendarEvent[]>([
-  { id: 'evt1', hour: 0, name: 'Morning Standup', color: 'tomato' },
-  { id: 'evt2', hour: 0, name: 'Client Call', color: 'gold' },
-  { id: 'evt3', hour: 2, name: 'Lunch with Team', color: 'limegreen' }, // 2 o'clock slice
-  { id: 'evt4', hour: 3, name: 'Project X Work', color: 'deepskyblue' },
-  { id: 'evt5', hour: 3, name: 'Review PRs', color: 'mediumpurple' },
-  { id: 'evt6', hour: 3, name: 'Quick Sync', color: 'lightcoral' }, // Max 3 dots per slice with current settings
-  { id: 'evt7', hour: 8, name: 'Evening Coding', color: 'darkorange' },
+  { id: 'evt1', sliceIndex: 0, name: 'Morning Standup', color: 'tomato' },
+  { id: 'evt2', sliceIndex: 0, name: 'Client Call', color: 'gold' },
+  { id: 'evt3', sliceIndex: 2, name: 'Lunch with Team', color: 'limegreen' }, // 2 o'clock slice
+  { id: 'evt4', sliceIndex: 3, name: 'Project X Work', color: 'deepskyblue' },
+  { id: 'evt5', sliceIndex: 3, name: 'Review PRs', color: 'mediumpurple' },
+  { id: 'evt6', sliceIndex: 3, name: 'Quick Sync', color: 'lightcoral' }, // Max 3 dots per slice with current settings
+  { id: 'evt7', sliceIndex: 8, name: 'Evening Coding', color: 'darkorange' },
 ])
 
 const numberOfSlices = 12
@@ -97,7 +77,7 @@ const slicesWithEvents = computed<SliceData[]>(() => {
     ].join(' ')
 
     // --- Event Dot Calculation for this slice ---
-    const sliceEvents = events.value.filter((event) => event.hour === i)
+    const sliceEvents = events.value.filter((event) => event.sliceIndex === i)
     const eventDots: EventDot[] = []
 
     // Calculate the middle angle of the current slice for dot placement


### PR DESCRIPTION
## Summary
- centralize `CalendarEvent`, `EventDot` and `SliceData` under `src/types`
- import these interfaces in the 4-week, 7-day and 12-hour views
- adjust TwelveHourView events to use `sliceIndex`

## Testing
- `npm run lint` *(fails: The 'jiti' library is required for loading TypeScript configuration files)*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f49dfbd608332934b9f4233bbd736